### PR TITLE
Fix tag generation to correctly clean '/' characters when the Dockerf…

### DIFF
--- a/stevedore.go
+++ b/stevedore.go
@@ -144,15 +144,13 @@ func generateRepoNames(base, path, tag, dockerfile string) []string {
 		base = base + "-" + path
 	}
 
+	name := base
+
 	// grab the suffix from the Dockerfile, if any (e.g. "Dockerfile.foo" => "foo")
 	suffix := dockerfile
 	if index := strings.LastIndex(suffix, "."); index != -1 {
-		suffix = suffix[index+1:]
-	} else {
-		return []string{base + ":" + tag, base + ":latest"}
+		name = name + "-" + suffix[index+1:]
 	}
-
-	name := base + "-" + suffix
 
 	// Docker image names can't have more than 2 '/' chars in them ¯\_(ツ)_/¯
 	// replace any offending '/' chars w/ '-'

--- a/stevedore_test.go
+++ b/stevedore_test.go
@@ -1,0 +1,39 @@
+package stevedore
+
+import (
+	"testing"
+
+	"github.com/zulily/stevedore/cmd"
+)
+
+type generateNamesTestCase struct {
+	registry string
+	args     []string
+	expected []string
+}
+
+var (
+	testGenerateRepoNamesCases = []generateNamesTestCase{
+		generateNamesTestCase{
+			registry: "gcr.io/mydomain",
+			args:     []string{"foo", "bar", "baz", "Dockerfile"},
+			expected: []string{"gcr.io/mydomain/foo-bar:baz", "gcr.io/mydomain/foo-bar:latest"},
+		},
+		generateNamesTestCase{
+			registry: "gcr.io/mydomain",
+			args:     []string{"foo", "bar", "baz", "Dockerfile.api"},
+			expected: []string{"gcr.io/mydomain/foo-bar-api:baz", "gcr.io/mydomain/foo-bar-api:latest"},
+		},
+	}
+)
+
+func TestGenerateRepoNames(t *testing.T) {
+	for _, testCase := range testGenerateRepoNamesCases {
+		cmd.Registry = testCase.registry
+		result := generateRepoNames(testCase.args[0], testCase.args[1], testCase.args[2], testCase.args[3])
+		if result[0] != testCase.expected[0] || result[1] != testCase.expected[1] {
+			t.Errorf("Expected (%q), got (%q)", testCase.expected, result)
+			t.FailNow()
+		}
+	}
+}


### PR DESCRIPTION
…ile(s) do not have a suffix